### PR TITLE
Small syntax change to appease Heroku

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,4 +16,4 @@ bot.login();
 
 http.createServer(function(req, res) {
     res.end('SLACK_CONNECT_4_BOT');
-}).listen(process.env.port || 5000);
+}).listen(process.env.PORT || 5000);


### PR DESCRIPTION
When I tried running this bot on Heroku it was crashing with this error:

`Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch`

Capitalizing "port" so that the env could set it seems to have fixed the problem.
