### PR TITLE
Add missing colon to emoji

### DIFF
--- a/src/connect4/emoji.js
+++ b/src/connect4/emoji.js
@@ -6,7 +6,7 @@ module.exports = {
         black: ':black_circle:'
     },
     number: {
-        0: ':zero',
+        0: ':zero:',
         1: ':one:',
         2: ':two:',
         3: ':three:',


### PR DESCRIPTION
Fixed this small error for you (although :zero: does not appear to be used).
